### PR TITLE
Allow install in Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~6.0"
+        "illuminate/support": ">=5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.0"
+        "illuminate/support": "~6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Remove constraint from illuminate/support to allow install this package on Laravel 6.0